### PR TITLE
changed the default DomainName from rancher.aws.private to aws.private

### DIFF
--- a/templates/rancher.template.yaml
+++ b/templates/rancher.template.yaml
@@ -89,7 +89,7 @@ Parameters:
   DomainName:
     Description: DNS domain name that users can use to access the Rancher console.
     Type: String
-    Default: rancher.aws.private
+    Default: aws.private
 
 Conditions:
   NoDomainSpecified: !Equals [ !Ref DomainName, '' ]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
